### PR TITLE
Adds rotation to the resize to fix orientation trouble

### DIFF
--- a/fpm/scripts/resize.php
+++ b/fpm/scripts/resize.php
@@ -63,6 +63,24 @@ if ($tokens[2] == "w800"){
 $image = new Imagick($orig_file);
 
 list($orig_width, $orig_height, $type, $attr) = getimagesize($orig_file);
+
+// Because the exif data is stripped we need to rotate to the right orientation
+$orientation = $image->getImageOrientation();
+switch ($orientation) {
+	case imagick::ORIENTATION_BOTTOMRIGHT: 
+		$image->rotateimage("#000", 180); // rotate 180 degrees
+		break;
+
+	case imagick::ORIENTATION_RIGHTTOP:
+		$image->rotateimage("#000", 90); // rotate 90 degrees CW
+		break;
+
+	case imagick::ORIENTATION_LEFTBOTTOM: 
+		$image->rotateimage("#000", -90); // rotate 90 degrees CCW
+		break;
+}
+$image->setImageOrientation(imagick::ORIENTATION_TOPLEFT);
+
  
 # preserve aspect ratio, fitting image to specified box
 if ($mode == "0")

--- a/fpm/scripts/resize.php
+++ b/fpm/scripts/resize.php
@@ -62,8 +62,6 @@ if ($tokens[2] == "w800"){
 
 $image = new Imagick($orig_file);
 
-list($orig_width, $orig_height, $type, $attr) = getimagesize($orig_file);
-
 // Because the exif data is stripped we need to rotate to the right orientation
 $orientation = $image->getImageOrientation();
 switch ($orientation) {
@@ -80,6 +78,9 @@ switch ($orientation) {
 		break;
 }
 $image->setImageOrientation(imagick::ORIENTATION_TOPLEFT);
+
+$orig_width = $image->getImageWidth();
+$orig_height = $image->getImageHeight();
 
  
 # preserve aspect ratio, fitting image to specified box


### PR DESCRIPTION
Door deze extra code wordt de afbeelding gedraaid voordat de EXIF data wordt gestript. Dit is [optie twee van het oplossen van LINNA-1505](https://jira.naturalis.nl/browse/LINNA-1505).