### PR TITLE
No longer strip the EXIF data so the browser knows what to do with it

### DIFF
--- a/fpm/scripts/resize.php
+++ b/fpm/scripts/resize.php
@@ -104,7 +104,6 @@ if(!file_exists($save_dir))
 
 $image->setImageCompression(imagick::COMPRESSION_JPEG);
 $image->setImageCompressionQuality(80);
-$image->stripImage();
 $image->writeImage($save_path);
 header('Content-type: image/jpg');
 echo file_get_contents($save_path);


### PR DESCRIPTION
Een andere oplossing voor het gebrek aan rotatie bij thumbnails is in stand houden van de EXIF data zodat de browser weet wat hij ermee moet.

Dit is [optie 1 van LINNA-1505](https://github.com/naturalis/docker-imageserver/pull/new/feature/stop-stripping). Er moet gekozen worden uit een van de twee pull requests. Het is ons om het even.